### PR TITLE
Add missing set_model_mode

### DIFF
--- a/R/parsnip-gen_additive_mod_data.R
+++ b/R/parsnip-gen_additive_mod_data.R
@@ -2,6 +2,7 @@
 
 make_gen_additive_reg <- function() {
     parsnip::set_new_model("gen_additive_reg")
+    parsnip::set_model_mode("gen_additive_reg", "regression")
 }
 
 make_gen_additive_reg_stan <- function() {


### PR DESCRIPTION
Hello @AlbertoAlmuinha 👋 

We are wrapping up for another CRAN release for {parsnip} soon. I noticed in the reverse dependency check that a `set_model_mode()` is missing.

You don't need to wait for us to update {parsnip} on CRAN before you can update {bayesmodels}.